### PR TITLE
Fixes #3 - ensure that exception is re-raised

### DIFF
--- a/src/serial/private/serialport/serialport_posix.nim
+++ b/src/serial/private/serialport/serialport_posix.nim
@@ -489,6 +489,8 @@ proc open*(port: SerialPort, baudRate: int32, parity: Parity, dataBits: byte, st
     discard posix.close(tempHandle)
     port.handle = InvalidFileHandle
 
+    raise
+
 proc read*(port: SerialPort, buff: pointer, len: int32): int32 =
   ## Read up to `len` bytes from the serial port into the buffer `buff`. This will return the actual number of bytes that were received.
   if not port.isOpen():

--- a/src/serial/private/serialport/serialport_windows.nim
+++ b/src/serial/private/serialport/serialport_windows.nim
@@ -498,6 +498,7 @@ proc initPort(port: SerialPort, tempHandle: Handle, baudRate: int32, parity: Par
   except:
     discard closeHandle(tempHandle)
     port.handle = InvalidFileHandle
+    
     raise
 
 proc open*(port: SerialPort, baudRate: int32, parity: Parity, dataBits: byte, stopBits: StopBits,


### PR DESCRIPTION
Fixes #3 by re-raising exception in `posix.open()`.