### PR TITLE
Easier reading and writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ port.baudRate = 2400
 
 var receiveBuffer = newString(1024)
 while true:
-  let numReceived = port.read(addr receiveBuffer[0], int32 len(receiveBuffer))
+  let numReceived = port.read(receiveBuffer)
   discard port.write(addr receiveBuffer[0], numReceived)
 ```
 

--- a/src/serial/private/serialport/serialport_posix.nim
+++ b/src/serial/private/serialport/serialport_posix.nim
@@ -19,10 +19,10 @@ var
   TIOCMBIS {.importc, header: "<termios.h>".}: cint
 
 type
-  SerialPortBase[THandle] = ref object of RootObj
+  SerialPortBase[HandleType] = ref object of RootObj
     name*: string
     handshake: Handshake
-    handle: THandle
+    handle: HandleType
     readTimeout: int32
     writeTimeout: int32
 

--- a/src/serial/private/serialport/serialport_windows.nim
+++ b/src/serial/private/serialport/serialport_windows.nim
@@ -14,10 +14,10 @@ const
   FileTemplateHandle: Handle = Handle(0)
 
 type
-  SerialPortBase[THandle] = ref object of RootObj
+  SerialPortBase[HandleType] = ref object of RootObj
     name*: string
     handshake: Handshake
-    handle: THandle
+    handle: HandleType
     commProp: CommProp
     comStat: ComStat
     dcb: DCB
@@ -491,14 +491,14 @@ proc initPort(port: SerialPort, tempHandle: Handle, baudRate: int32, parity: Par
 
     if GetCommTimeouts(port.handle, addr port.commTimeouts) == 0:
       raiseOSError(osLastError())
-      
+
     port.setTimeouts(readTimeout, writeTimeout)
 
     discard SetCommMask(port.handle, ALL_EVENTS)
   except:
     discard closeHandle(tempHandle)
     port.handle = InvalidFileHandle
-    
+
     raise
 
 proc open*(port: SerialPort, baudRate: int32, parity: Parity, dataBits: byte, stopBits: StopBits,

--- a/src/serial/serialport.nim
+++ b/src/serial/serialport.nim
@@ -6,3 +6,17 @@ elif defined(posix):
   include ./private/serialport/serialport_posix
 else:
   {.error: "Serial port handling not implemented for your platform".}
+
+proc read*(port: SerialPort, buff: var string): int32 =
+  ## Read from the serial port into the buffer `buff`. This will return the actual number of bytes that were received.
+  if isNil(buff) or len(buff) == 0:
+    return 0
+
+  result = port.read(addr buff[0], int32(len(buff)))
+
+proc write*(port: SerialPort, buff: var string): int32 =
+  ## Write the data to the serialport `port` from the buffer `buff`. This will return the number of bytes that were written.
+  if isNil(buff) or len(buff) == 0:
+    return 0
+
+  result = port.write(addr buff[0], int32(len(buff)))


### PR DESCRIPTION
This adds wrapper procs for reading from and writing to the serial port that allow the passing of `var string`.

It also prevents an invalid deprecation warning relating to `THandle` due to there being a type named `THandle` in `winlean`.