### PR TITLE
fix IndexError in serial.nim example

### DIFF
--- a/src/serial.nim
+++ b/src/serial.nim
@@ -89,7 +89,7 @@ when isMainModule:
   var writeBuff = "Hello, World\n"
   let numWritten = port.write(addr writeBuff[0], int32(len(writeBuff)))
 
-  echo "Wrote ", numWritten, " bytes: ", writeBuff[0..numWritten]
+  echo "Wrote ", numWritten, " bytes: ", writeBuff[0..numWritten-1]
 
   var buff: string = newString(1024)
   let numRead = port.read(addr buff[0], int32(len(buff)))


### PR DESCRIPTION
Running `src/serial.nim` raises an unhandled exception on line 92:
`Error: unhandled exception: index 13 not in 0 .. 12 [IndexError]`
I'm writing "Hello, World\n", so length is 13 characters.