### PR TITLE
Check for PCustomOverlapped being defined

### DIFF
--- a/src/serial/private/serialport/serialport_windows.nim
+++ b/src/serial/private/serialport/serialport_windows.nim
@@ -634,8 +634,12 @@ proc read*(port: AsyncSerialPort, buff: pointer, len: int32): Future[int32] =
     retFuture.fail(newException(OSError, osErrorMsg(osLastError())))
     return retFuture
 
-  var ol = PCustomOverlapped()
-  GC_ref(ol)
+  when declared(PCustomOverlapped):
+    var ol = PCustomOverlapped()
+    GC_ref(ol)
+  else:
+    var ol = asyncdispatch.newCustom()
+
   ol.data = CompletionData(fd: port.handle, cb: proc(fd: AsyncFD,
       bytesCount: DWORD, errorCode: OSErrorCode) =
     if not retFuture.finished:
@@ -692,8 +696,12 @@ proc write*(port: AsyncSerialPort, buff: pointer, len: int32): Future[int32] =
     retFuture.fail(newException(OSError, osErrorMsg(osLastError())))
     return retFuture
 
-  var ol = PCustomOverlapped()
-  GC_ref(ol)
+  when declared(PCustomOverlapped):
+    var ol = PCustomOverlapped()
+    GC_ref(ol)
+  else:
+    var ol = asyncdispatch.newCustom()
+
   ol.data = CompletionData(fd: port.handle, cb: proc(fd: AsyncFD,
       bytesCount: DWORD, errorCode: OSErrorCode) =
     if not retFuture.finished:


### PR DESCRIPTION
Fixes #44.

This checks if `PCustomOverlapped` is declared, and if not it uses [`asyncdispatch.newCustom`](https://nim-lang.org/docs/asyncdispatch.html#newCustom).