### PR TITLE
Fixes for latest Nim

### DIFF
--- a/src/serial/private/ffi/ffi_windows.nim
+++ b/src/serial/private/ffi/ffi_windows.nim
@@ -224,13 +224,7 @@ proc ClearCommError*(hFile: Handle, lpErrors: ptr DWORD,
     lpStat: ptr ComStat): WINBOOL {.stdcall, dynlib: "kernel32",
     importc: "ClearCommError".}
 
-when useWinUnicode:
-  const CreateFileWindows* = createFileW
-else:
-  const CreateFileWindows* = createFileA
+const CreateFileWindows* = createFileW
 
 template getWindowsString*(str: string): untyped =
-  when useWinUnicode:
-    newWideCString(str)
-  else:
-    cstring(str)
+  newWideCString(str)

--- a/src/serial/private/serialport/serialport_common.nim
+++ b/src/serial/private/serialport/serialport_common.nim
@@ -27,17 +27,17 @@ type
     Two = 2,
     OnePointFive = 3
 
-  InvalidSerialPortError* = object of Exception
+  InvalidSerialPortError* = object of IOError
 
   TimeoutError* = object of IOError
 
   InvalidSerialPortStateError* = object of IOError
 
-  InvalidBaudRateError* = object of Exception
+  InvalidBaudRateError* = object of ValueError
 
-  InvalidDataBitsError* = object of Exception
+  InvalidDataBitsError* = object of ValueError
 
-  InvalidStopBitsError* = object of Exception
+  InvalidStopBitsError* = object of IOError
 
   ReceivedError* {.pure.} = enum
     ## Types of error detected by the operating system whilst reading from/writing to a serial port.

--- a/src/serial/private/serialport/serialport_common.nim
+++ b/src/serial/private/serialport/serialport_common.nim
@@ -37,7 +37,7 @@ type
 
   InvalidDataBitsError* = object of ValueError
 
-  InvalidStopBitsError* = object of IOError
+  InvalidStopBitsError* = object of ValueError
 
   ReceivedError* {.pure.} = enum
     ## Types of error detected by the operating system whilst reading from/writing to a serial port.

--- a/src/serial/private/serialport/serialport_windows.nim
+++ b/src/serial/private/serialport/serialport_windows.nim
@@ -760,8 +760,8 @@ proc close*(port: SerialPort | AsyncSerialPort) =
       if EscapeCommFunction(Handle(port.handle), CLRDTR) == 0:
         let lastError = int32(osLastError())
 
-        if lastError in {ERROR_ACCESS_DENIED, ERROR_BAD_COMMAND,
-            ERROR_DEVICE_REMOVED}:
+        if lastError in [ERROR_ACCESS_DENIED, ERROR_BAD_COMMAND,
+            ERROR_DEVICE_REMOVED]:
           skipFlush = true
         else:
           # Unknown error

--- a/src/serial/private/utils/windows_registry.nim
+++ b/src/serial/private/utils/windows_registry.nim
@@ -86,7 +86,7 @@ iterator enumKeyValues*(path: string, handle: HKEY): tuple[key:string, value:str
     call regEnumValue(newHandle, int32(i), regName, addr regNameSize, nil, nil, nil, addr regValueSize)
     var regValue = newWideCString("", regValueSize)
     regNameSize += 2 # reallocate for null wchar.
-    call regEnumValue(newHandle, int32(i), regName, addr regNameSize, nil, nil, cast[pointer](regValue), addr regValueSize)
+    call regEnumValue(newHandle, int32(i), regName, addr regNameSize, nil, nil, addr regValue[0], addr regValueSize)
     yield (regName $ regNameSize, regValue $ regValueSize)
   
   call regCloseKey(newHandle)
@@ -110,13 +110,13 @@ proc getUnicodeValue*(path, key: string; handle: HKEY): string =
     call regOpenKeyEx(handle, hh, 0, KEY_READ or KEY_WOW64_64KEY, newHandle)
     call regGetValue(newHandle, nil, kk, flags, nil, nil, addr bufsize)
     var res = newWideCString("", bufsize)
-    call regGetValue(newHandle, nil, kk, flags, nil, cast[pointer](res),
+    call regGetValue(newHandle, nil, kk, flags, nil, addr res[0],
                    addr bufsize)
     result = res $ bufsize
     call regCloseKey(newHandle)
   else:
     var res = newWideCString("", bufsize)
-    call regGetValue(handle, hh, kk, flags, nil, cast[pointer](res),
+    call regGetValue(handle, hh, kk, flags, nil, addr res[0],
                    addr bufsize)
     result = res $ bufsize
 


### PR DESCRIPTION
* `useWinUnicode` was removed a while ago, now typically only the Unicode APIs are used (see https://github.com/nim-lang/Nim/pull/21315).
* Deriving exceptions directly off `Exception` generated some warnings saying that they should be derived of a more concrete exception type.
* Putting together a set of int consts/literals would previously create an int16 set, now it's an error. So I replaced the set by an array.
* Getting the pointer of the wide string by casting it to pointer seems to not work anymore? It works this way (which I think should also be more stable).

Only tested on Windows, there might still remain issues on other platforms.